### PR TITLE
Updated Intel MKL library PubKey in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install -y build-essential \
 
 # Intel MKL - for Marian usage on CPU
 RUN apt install wget && \
-    wget -qO- 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB' |  apt-key add -
+    wget -qO- 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB' |  apt-key add -
 RUN sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list' && \
     apt-get update && \
     apt-get install -y intel-mkl-64bit-2020.0-088


### PR DESCRIPTION
Updated the Intel MKL library PubKey from the 2019 version to the generic version, so that the Docker image builds successfully (as of February 2024).